### PR TITLE
Enable disable static hostname

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ collectd_network_auth_file_path: '/etc/collectd/network_server_auth.db'
 
 
 # Main configuration
+collectd_static_hostname: 'true'
 collectd_hostname: "{{ ansible_hostname }}"
 collectd_fqdn_lookup: 'true'
 collectd_base_dir: '/var/lib/collectd'

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -35,6 +35,7 @@ collectd_network_auth_file_path: '/etc/collectd/network_server_auth.db'
 
 
 # Main configuration
+collectd_static_hostname: 'true'
 collectd_hostname: "{{ ansible_hostname }}"
 collectd_fqdn_lookup: 'true'
 collectd_base_dir: '/var/lib/collectd'

--- a/templates/etc/collectd/collectd.conf.j2
+++ b/templates/etc/collectd/collectd.conf.j2
@@ -7,7 +7,7 @@
 # Global settings for the daemon.                                            #
 ##############################################################################
 
-{% if (collectd_fqdn_lookup != 'true') %}
+{% if (collectd_static_hostname == 'true') %}
 Hostname "{{ collectd_hostname }}"
 {% endif %}
 FQDNLookup {{ collectd_fqdn_lookup }}

--- a/templates/etc/collectd/collectd.conf.j2
+++ b/templates/etc/collectd/collectd.conf.j2
@@ -7,7 +7,9 @@
 # Global settings for the daemon.                                            #
 ##############################################################################
 
+{% if (collectd_fqdn_lookup != 'true') %}
 Hostname "{{ collectd_hostname }}"
+{% endif %}
 FQDNLookup {{ collectd_fqdn_lookup }}
 BaseDir "{{ collectd_base_dir }}"
 PluginDir "{{ collectd_plugin_dir }}"


### PR DESCRIPTION
The hostname must be configured to be static or dynamic. When the hostname is not ansible-user, the possibility of dynamically obtaining the hostname should be allowed. This use case is related to images created using ansible that cannot have static values.